### PR TITLE
Add a simple command line tool to manage modules in the DB

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 /*eslint no-console: 0 */
+const nodePlv8Schema = process.env.NODE_PLV8_SCHEMA || 'v8'
 const bootstrapPlv8 = require('./lib/bootstrap')
 const babel = require('babel-core')
 const browserify = require('browserify')
@@ -55,13 +56,13 @@ module.exports = class PLV8 {
       })
     })
     .then(code => {
-      return this.knex('v8.modules').select('*').where({ name: moduleName })
+      return this.knex(nodePlv8Schema+'.modules').select('*').where({ name: moduleName })
         .then(result => {
           if (result.length > 0) {
-            return this.knex('v8.modules').update({ code }).where({ name: moduleName })
+            return this.knex(nodePlv8Schema+'.modules').update({ code }).where({ name: moduleName })
           }
           else {
-            return this.knex('v8.modules').insert({ code, name: moduleName })
+            return this.knex(nodePlv8Schema+'.modules').insert({ code, name: moduleName })
           }
         })
     })
@@ -70,7 +71,7 @@ module.exports = class PLV8 {
 
   uninstall (moduleId) {
     const name = moduleId.replace(/^@\w+\//, '')
-    return this.knex('v8.modules').where({ name }).del()
+    return this.knex(nodePlv8Schema+'.modules').where({ name }).del()
       .then(() => true)
   }
 
@@ -135,13 +136,13 @@ module.exports = class PLV8 {
   }
 
   init () {
-    return this.knex('pg_catalog.pg_namespace').select().where({ nspname: 'v8' })
+    return this.knex('pg_catalog.pg_namespace').select().where({ nspname: nodePlv8Schema })
       .then(([ schema ]) => {
         if (schema) {
           return
         }
         else {
-          return this.knex.raw('create schema if not exists "v8"')
+          return this.knex.raw('create schema if not exists nodePlv8Schema+""')
         }
       })
       .then(() => {
@@ -156,7 +157,7 @@ module.exports = class PLV8 {
           })
       })
       .then(() => {
-        return this.knex.schema.createTableIfNotExists('v8.modules', table => {
+        return this.knex.schema.createTableIfNotExists(nodePlv8Schema+'.modules', table => {
           table.increments()
           table.text('name')
           table.text('code')
@@ -169,5 +170,6 @@ module.exports = class PLV8 {
 
   constructor (knex) {
     this.knex = knex
+    this.nodePlv8Schema = nodePlv8Schema
   }
 }

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -53,44 +53,44 @@ module.exports = function(knex) {
         EXCEPTION WHEN OTHERS THEN END;
       $$;`.replace(/\n/g, ''))
     .then(() => {
-      return knex.raw(`SET plv8.start_proc = 'v8.plv8_init';`)
+      return knex.raw(`SET plv8.start_proc = nodePlv8Schema+'.plv8_init';`)
     })
     .then(() => {
       return knex.raw(`
         DO $$ BEGIN
-          CREATE DOMAIN v8.json AS json;
+          CREATE DOMAIN ${nodePlv8Schema}.json AS json;
           EXCEPTION WHEN OTHERS THEN END;
       $$;`.replace(/\n/g, ''))
     })
     .then(() => {
-      return knex.raw(createStoredProcedure('v8.plv8_init', { }, 'void', plv8_init(), true))
+      return knex.raw(createStoredProcedure(nodePlv8Schema+'.plv8_init', { }, 'void', plv8_init(), true))
     })
     .then(() => {
       return Promise.all([
-        knex.raw(createStoredProcedure('v8.eval', {
+        knex.raw(createStoredProcedure(nodePlv8Schema+'.eval', {
           str: 'text'
-        }, 'v8.json', plv8_eval)),
-        knex.raw(createStoredProcedure('v8.apply', {
+        }, nodePlv8Schema+'.json', plv8_eval)),
+        knex.raw(createStoredProcedure(nodePlv8Schema+'.apply', {
           str: 'text',
-          args: 'v8.json'
-        }, 'v8.json', plv8_apply)),
-        knex.raw(createStoredProcedure('v8.json_eval', {
+          args: nodePlv8Schema+'.json'
+        }, nodePlv8Schema+'.json', plv8_apply)),
+        knex.raw(createStoredProcedure(nodePlv8Schema+'.json_eval', {
           code: 'text'
-        }, 'v8.json', wrapStoredProcedure(0), {
+        }, nodePlv8Schema+'.json', wrapStoredProcedure(0), {
           cascade: true,
           boot: true
         })),
-        knex.raw(createStoredProcedure('v8.json_eval', {
-          data: 'v8.json',
+        knex.raw(createStoredProcedure(nodePlv8Schema+'.json_eval', {
+          data: nodePlv8Schema+'.json',
           code: 'text'
-        }, 'v8.json', wrapStoredProcedure(-1), {
+        }, nodePlv8Schema+'.json', wrapStoredProcedure(-1), {
           cascade: true,
           boot: true
         })),
-        knex.raw(createStoredProcedure('v8.json_eval', {
+        knex.raw(createStoredProcedure(nodePlv8Schema+'.json_eval', {
           code: 'text',
-          data: 'v8.json'
-        }, 'v8.json', wrapStoredProcedure(1), {
+          data: nodePlv8Schema+'.json'
+        }, nodePlv8Schema+'.json', wrapStoredProcedure(1), {
           cascade: true,
           boot: true
         }))
@@ -106,7 +106,7 @@ function plv8_apply (func, args){
 }
 
 function plv8_require (name) {
-  var module = plv8.execute('select name, code from v8.modules where name = $1', [ name ])[0];
+  var module = plv8.execute('select name, code from '+nodePlv8Schema+'.modules where name = $1', [ name ])[0];
 
   if (!module) {
     plv8.elog(WARNING, 'Cannot find module \'' + name + '\'');
@@ -137,7 +137,7 @@ function wrapStoredProcedure (type = 1) {
 function createStoredProcedure (name, paramObj, ret, func, init) {
   const signature = _.map(paramObj, (type, key) => {
     return {
-      arg: (type === 'v8.json') ? `JSON.parse('${key}')` : key,
+      arg: (type === nodePlv8Schema+'.json') ? `JSON.parse('${key}')` : key,
       param: `${key} ${type}`
     }
   })
@@ -148,11 +148,11 @@ function createStoredProcedure (name, paramObj, ret, func, init) {
 
   let statement = `(${code})(${args})`
 
-  if (ret === 'v8.json') {
+  if (ret === nodePlv8Schema+'.json') {
     statement = `JSON.stringify(${statement})`
   }
 
-  let initStatement = 'plv8.execute("select v8.plv8_init()");'
+  let initStatement = 'plv8.execute("select "+nodePlv8Schema+".plv8_init()");'
   if (init) {
     initStatement = ''
   }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const program = require('commander')
+
+program
+  .version('1.0.0')
+  .option('-U, --user <user>', 'database user name', 'postgres')
+  .option('-H, --host <host>', 'database server hostname or IP or socket', 'localhost')
+  .option('-p, --port <port>', 'database server port', 5432)
+  .option('-d, --db <db>', 'database name to connect to', 'postgres')
+
+program
+  .command('install <modules...>')
+  .description('install one or more packages into the DB')
+  .alias('i')
+  .action((command, modules, options) => install(modules,options))
+
+program
+  .command('uninstall <module...>')
+  .description('uninstall one or more packages from the DB')
+  .alias('u')
+  .action((command, modules, options) => uninstall(modules,options))
+
+program
+  .command('list')
+  .description('list the packages currently installed in the DB')
+  .alias('l')
+  .action((options) => list(options))
+
+program.parse(process.argv)
+
+function init(options) {
+  const globalOpts = options.parent
+  const PLV8 = require('..'),
+    knex = require('knex'),
+    plv8 = new PLV8(knex({
+      client: 'pg',
+      connection: {
+        host: globalOpts.host,
+        database: globalOpts.db,
+        user: globalOpts.user,
+        password: process.env.PGPASS
+      }
+    }))
+  return plv8
+}
+
+
+function list(options) {
+  const plv8 = init(options)
+  console.log('Currently installed modules:')
+  plv8.knex
+    .select('name')
+    .from(`${plv8.nodePlv8Schema}.modules`)
+    .then(result => {
+      result.forEach(row => console.log(row.name));
+    })
+    .then(() => plv8.knex.destroy() )
+    .catch(err => {
+      console.log(""+err)
+      process.exit(1)
+    })
+}
+
+function uninstall(modules, options) {
+  const plv8 = init(options)
+  modules.forEach(name => {
+    plv8.knex(`${plv8.nodePlv8Schema}.modules`)
+      .where({name})
+      .del()
+      .returning({name})
+      .then(result => console.log(`${result} removed`) )
+      .then(() => plv8.knex.destroy() )
+      .catch(err => {
+        console.log(""+err)
+        process.exit(1)
+      })
+  })
+}
+
+function install(modules, options) {
+  if (!modules.length) {
+    console.error('One or more package arguments required.')
+    process.exit(1)
+  }
+
+  const plv8 = init(options)
+  let moduleInstalls = modules.reduce((promiseChain, item) => {
+    return promiseChain.then(() => new Promise((resolve) => {
+      plv8
+        .install({
+          modulePath: require.resolve(item),
+          moduleName: item
+        })
+        .then(moduleName => {
+          console.log(`module ${moduleName} installed`)
+          resolve()
+        })
+        .catch(err => {
+          console.log(""+err)
+          process.exit(1)
+        })
+    }))
+  }, Promise.resolve())
+
+
+  moduleInstalls
+    .then(() => plv8.knex.destroy() )
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babelify": "^7.3.0",
     "browserify": "^13.1.0",
+    "commander": "^2.9.0",
     "lodash": "^4.13.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "require"
   ],
   "main": "index.js",
+  "bin": "./lib/cli.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/langateam/plv8.git"


### PR DESCRIPTION
I know that you pulled the cli out of node_plv8 when you forked,
but I am using it to manage modules that are used inside the DB
and I needed a simple cli to install, uninstall, and list them.
Would like to add something to show the current version, but
since that isn't currently stored in the modules table, I left it out.