### PR TITLE
Build knex object in constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const bootstrapPlv8 = require('./lib/bootstrap')
 const babel = require('babel-core')
 const browserify = require('browserify')
 const babelify = require('babelify')
+const knex = require('knex');
 const babelOptions = {
   presets: [
     require('babel-preset-es2015')
@@ -167,7 +168,7 @@ module.exports = class PLV8 {
       })
   }
 
-  constructor (knex) {
-    this.knex = knex
+  constructor (config) {
+    this.knex = knex(config)
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@ const knex = require('knex')
 const PLV8 = require('../')
 
 describe('plv8', () => {
-  const knexHandle = knex({
+  const config= {
     client: 'pg',
     connection: {
       host: process.env.PLV8_HOST,
@@ -11,8 +11,9 @@ describe('plv8', () => {
       password: process.env.PLV8_PASSWORD,
       database: process.env.PLV8_DATABASE
     }
-  })
-  const plv8 = new PLV8(knexHandle)
+  };
+  const knexHandle = knex(config)
+  const plv8 = new PLV8(config)
 
   describe('#install', () => {
     it('should install a module', () => {


### PR DESCRIPTION
I don't want to have to pull in knex as a dependency to my project. This PR addresses that leak by changing the PLV8 constructor to take a POJO and build a knex object from it.